### PR TITLE
[fix] Fix incorrect github name in go mod

### DIFF
--- a/cmd/matchmaking/main.go
+++ b/cmd/matchmaking/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/api/websocket"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
-	"lesta-battleship/server-core/internal/matchmaking/infra/registries"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/api/websocket"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/infra/registries"
 
 	"github.com/gin-gonic/gin"
 )

--- a/examples/websocket/client/client.go
+++ b/examples/websocket/client/client.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"lesta-battleship/server-core/pkg/packets"
 	"log"
 	"net/url"
 	"os"
 	"os/signal"
+
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 
 	"github.com/gorilla/websocket"
 )

--- a/examples/websocket/server/server.go
+++ b/examples/websocket/server/server.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"lesta-battleship/server-core/internal/api/websocket"
-	"lesta-battleship/server-core/internal/infra/registries"
-	"lesta-battleship/server-core/internal/app/multiplayer"
-	"lesta-battleship/server-core/internal/app/multiplayer/actors/matchmakers"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/api/websocket"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/infra/registries"
 
 	"github.com/gin-gonic/gin"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module lesta-battleship/server-core
+module github.com/lesta-battleship/server-core
 
 go 1.24.4
 

--- a/internal/matchmaking/api/websocket/handlers.go
+++ b/internal/matchmaking/api/websocket/handlers.go
@@ -1,8 +1,8 @@
 package websocket
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
 
 	"github.com/gin-gonic/gin"
 )

--- a/internal/matchmaking/api/websocket/router.go
+++ b/internal/matchmaking/api/websocket/router.go
@@ -1,7 +1,7 @@
 package websocket
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer"
 
 	"github.com/gin-gonic/gin"
 )

--- a/internal/matchmaking/api/websocket/server.go
+++ b/internal/matchmaking/api/websocket/server.go
@@ -1,9 +1,10 @@
 package websocket
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/infra"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
 	"net/http"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/infra"
 
 	"github.com/gorilla/websocket"
 )

--- a/internal/matchmaking/app/multiplayer/actors/actor.go
+++ b/internal/matchmaking/app/multiplayer/actors/actor.go
@@ -1,6 +1,6 @@
 package actors
 
-import "lesta-battleship/server-core/pkg/matchmaking/packets"
+import "github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 
 type Actor interface {
 	Id() string

--- a/internal/matchmaking/app/multiplayer/actors/clientInterfacer.go
+++ b/internal/matchmaking/app/multiplayer/actors/clientInterfacer.go
@@ -1,7 +1,7 @@
 package actors
 
 import (
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type ClientInterfacer interface {

--- a/internal/matchmaking/app/multiplayer/actors/hubs/hub.go
+++ b/internal/matchmaking/app/multiplayer/actors/hubs/hub.go
@@ -1,10 +1,10 @@
 package hubs
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/rooms"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/rooms"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
 )
 

--- a/internal/matchmaking/app/multiplayer/actors/matchmakers/matchmaker.go
+++ b/internal/matchmaking/app/multiplayer/actors/matchmakers/matchmaker.go
@@ -1,12 +1,13 @@
 package matchmakers
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/infra"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/rooms"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/rooms"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/infra"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type Matchmaker struct {

--- a/internal/matchmaking/app/multiplayer/actors/matchmakers/strategies/custom.go
+++ b/internal/matchmaking/app/multiplayer/actors/matchmakers/strategies/custom.go
@@ -1,9 +1,10 @@
 package strategies
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type Custom struct {

--- a/internal/matchmaking/app/multiplayer/actors/matchmakers/strategies/random.go
+++ b/internal/matchmaking/app/multiplayer/actors/matchmakers/strategies/random.go
@@ -1,15 +1,15 @@
 package strategies
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type Random struct {
 	Matchmaker actors.Matchmaker
 
-	Hub        actors.Actor
+	Hub   actors.Actor
 	Queue map[string]*players.Player
 }
 

--- a/internal/matchmaking/app/multiplayer/actors/matchmakers/strategies/ranked.go
+++ b/internal/matchmaking/app/multiplayer/actors/matchmakers/strategies/ranked.go
@@ -1,10 +1,11 @@
 package strategies
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type Ranked struct {

--- a/internal/matchmaking/app/multiplayer/actors/matchmakers/strategy.go
+++ b/internal/matchmaking/app/multiplayer/actors/matchmakers/strategy.go
@@ -2,8 +2,9 @@ package matchmakers
 
 import (
 	"fmt"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers/strategies"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers/strategies"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type Strategy interface {

--- a/internal/matchmaking/app/multiplayer/actors/players/player.go
+++ b/internal/matchmaking/app/multiplayer/actors/players/player.go
@@ -1,9 +1,10 @@
 package players
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type Player struct {

--- a/internal/matchmaking/app/multiplayer/actors/players/strategies/inHub.go
+++ b/internal/matchmaking/app/multiplayer/actors/players/strategies/inHub.go
@@ -1,9 +1,10 @@
 package strategies
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type InHub struct {

--- a/internal/matchmaking/app/multiplayer/actors/players/strategies/inRoom.go
+++ b/internal/matchmaking/app/multiplayer/actors/players/strategies/inRoom.go
@@ -1,9 +1,10 @@
 package strategies
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type InRoom struct {

--- a/internal/matchmaking/app/multiplayer/actors/players/strategies/inSearch.go
+++ b/internal/matchmaking/app/multiplayer/actors/players/strategies/inSearch.go
@@ -1,9 +1,10 @@
 package strategies
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type InSearch struct {

--- a/internal/matchmaking/app/multiplayer/actors/players/strategy.go
+++ b/internal/matchmaking/app/multiplayer/actors/players/strategy.go
@@ -2,9 +2,10 @@ package players
 
 import (
 	"fmt"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players/strategies"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players/strategies"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type Strategy interface {

--- a/internal/matchmaking/app/multiplayer/actors/rooms/room.go
+++ b/internal/matchmaking/app/multiplayer/actors/rooms/room.go
@@ -2,10 +2,11 @@ package rooms
 
 import (
 	"fmt"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 const MaxPlayers = 2
@@ -116,7 +117,7 @@ func (r *Room) handleDisconnect(senderId string, packet *packets.Disconnect) err
 			return nil
 		}
 	}
-	//TODO: Close Room when empty
+	// TODO: Close Room when empty
 
 	return ErrNotConnectedToRoom
 }

--- a/internal/matchmaking/app/multiplayer/engine.go
+++ b/internal/matchmaking/app/multiplayer/engine.go
@@ -1,14 +1,15 @@
 package multiplayer
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/infra"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/hubs"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/rooms"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/hubs"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/rooms"
+	"github.com/lesta-battleship/server-core/internal/matchmaking/infra"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 )
 
 type Engine struct {

--- a/internal/matchmaking/infra/registries/matchmakerRegistry.go
+++ b/internal/matchmaking/infra/registries/matchmakerRegistry.go
@@ -1,6 +1,6 @@
 package registries
 
-import "lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
+import "github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/matchmakers"
 
 type MatchmakerRegistry struct {
 	players map[string]*matchmakers.Matchmaker

--- a/internal/matchmaking/infra/registries/playerRegistry.go
+++ b/internal/matchmaking/infra/registries/playerRegistry.go
@@ -1,6 +1,6 @@
 package registries
 
-import "lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
+import "github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/players"
 
 type PlayerRegistry struct {
 	players map[string]*players.Player

--- a/internal/matchmaking/infra/registries/roomRegistry.go
+++ b/internal/matchmaking/infra/registries/roomRegistry.go
@@ -1,6 +1,6 @@
 package registries
 
-import "lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/rooms"
+import "github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors/rooms"
 
 type RoomRegistry struct {
 	rooms map[string]*rooms.Room

--- a/internal/matchmaking/infra/websocketInterfacer.go
+++ b/internal/matchmaking/infra/websocketInterfacer.go
@@ -1,9 +1,10 @@
 package infra
 
 import (
-	"lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
-	"lesta-battleship/server-core/pkg/matchmaking/packets"
 	"log"
+
+	"github.com/lesta-battleship/server-core/internal/matchmaking/app/multiplayer/actors"
+	"github.com/lesta-battleship/server-core/pkg/matchmaking/packets"
 
 	"github.com/gorilla/websocket"
 )


### PR DESCRIPTION
Этот пуллреквест добавляет приписку github.com для возможности импорта cli модуля packets.